### PR TITLE
dev-rokers: Add ROS (v3)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "meta-linaro"]
 	path = meta-linaro
 	url = https://git.linaro.org/openembedded/meta-linaro.git
+[submodule "meta-ros"]
+	path = meta-ros
+	url = https://github.com/bmwcarit/meta-ros

--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "meta-ros"]
 	path = meta-ros
 	url = https://github.com/bmwcarit/meta-ros
+[submodule "openembedded-core"]
+	path = openembedded-core
+	url = git://git.openembedded.org/openembedded-core

--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ To build:
     bitbake genivi-dev-platform
 
 Please see the README in meta-genivi-dev for further information.
+

--- a/gdp-src-build/rokers-developer.conf
+++ b/gdp-src-build/rokers-developer.conf
@@ -2,6 +2,10 @@
 
 BBLAYERS += " \
   ${TOPDIR}/../meta-rokers \
+  ${TOPDIR}/../openembedded-core/meta \
+  ${TOPDIR}/../meta-openembedded/meta-oe \
+  ${TOPDIR}/../meta-openembedded/meta-python \
+  ${TOPDIR}/../meta-openembedded/meta-multimedia \
   ${TOPDIR}/../meta-ros \
   "
 

--- a/gdp-src-build/rokers-developer.conf
+++ b/gdp-src-build/rokers-developer.conf
@@ -2,6 +2,7 @@
 
 BBLAYERS += " \
   ${TOPDIR}/../meta-rokers \
+  ${TOPDIR}/../meta-ros \
   "
 
 # EOF

--- a/meta-rokers/recipes-rokers/images/rokers-image-base.bb
+++ b/meta-rokers/recipes-rokers/images/rokers-image-base.bb
@@ -30,6 +30,7 @@ PV ?= "snapshot+${DATE}"
 
 IMAGE_INSTALL_append = " \
     busybox-udhcpc \
+    roslaunch
 "
 
 # EOF

--- a/meta-rokers/recipes-rokers/images/rokers-image-base.bb
+++ b/meta-rokers/recipes-rokers/images/rokers-image-base.bb
@@ -30,6 +30,7 @@ PV ?= "snapshot+${DATE}"
 
 IMAGE_INSTALL_append = " \
     busybox-udhcpc \
+    roslaunch \
 "
 
 # EOF


### PR DESCRIPTION
This PR contains EXACTLY the same commits of PR https://github.com/robotrokers/genivi-dev-platform/pull/11
and is only aimed at verifying whether the build failure on pacakge `openssl-native` can be reproduced.

Signed-off-by: Gianpaolo Macario <gmacario@gmail.com>